### PR TITLE
update ReactToolbar for support RN 0.65

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/toolbarandroid/ReactToolbar.java
+++ b/android/src/main/java/com/reactnativecommunity/toolbarandroid/ReactToolbar.java
@@ -29,6 +29,9 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.PixelUtil;
 
+import java.util.Map;
+import java.util.HashMap;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -128,7 +131,12 @@ public class ReactToolbar extends Toolbar {
     public QualityInfo getQualityInfo() {
       return null;
     }
-
+    
+    @Override
+    @Nonnull
+    public Map<String, Object> getExtras(){
+      return new HashMap<String, Object>();
+    }
   }
 
   public ReactToolbar(Context context) {


### PR DESCRIPTION
React-Native requires Fresco version v2.5.0 after version 0.65.0.
After Fresco v2.3.0, package request `ImageInfo` to implement `HasImageMetadata`

React-Native 在 0.65.0 版本之后要求 Fresco 版本 v2.5.0。
Fresco v2.3.0之后要求 `ImageInfo` 实现 `HasImageMetadata` 接口